### PR TITLE
add Gem lockfiles to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 **/totez.yml
 spec/log/*.log
 spec/tmp/*
+gemfiles/*.lock
+Gemfile.lock


### PR DESCRIPTION
Appraisal gem recommends that you ignore the lockfiles for more
consistency on CI.